### PR TITLE
Feature/release setup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,7 +73,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation project(":core")
-    implementation project(":error-handler-core")
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.1.1'
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
+        classpath 'com.halcyonmobile.publish.artifactory-bintray:java-and-aar:0.1.0.7'
     }
 }
 
@@ -89,3 +90,4 @@ tasks.withType(io.gitlab.arturbosch.detekt.Detekt) {
 }
 
 apply plugin: 'io.gitlab.arturbosch.detekt'
+apply from: "./deploy.gradle"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'kotlin-kapt'
 
 dependencies {
 
+    api project(":error-handler-core")
     api project(':error-handler-rest')
-    implementation project(":error-handler-core")
 
     // Kotlin + Coroutines
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-kapt'
 
 dependencies {
 
-    api project(":error-handler-core")
     api project(':error-handler-rest')
 
     // Kotlin + Coroutines

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -1,0 +1,3 @@
+ext.libraryGroupId = 'error-handler'
+ext.libraryVersion = '0.1.0'
+ext.bintray_source_url = "https://github.com/halcyonmobile/error-handler"

--- a/error-handler-core/build.gradle
+++ b/error-handler-core/build.gradle
@@ -8,3 +8,6 @@ dependencies {
 
 sourceCompatibility = "8"
 targetCompatibility = "8"
+
+project.ext.set("libraryArtifactId", "core")
+apply plugin: 'com.halcyonmobile.plugin.publish.artifactory.jar-library'

--- a/error-handler-rest/build.gradle
+++ b/error-handler-rest/build.gradle
@@ -22,3 +22,6 @@ dependencies {
 
 sourceCompatibility = "8"
 targetCompatibility = "8"
+
+project.ext.set("libraryArtifactId", "rest")
+apply plugin: 'com.halcyonmobile.plugin.publish.artifactory.jar-library'

--- a/error-handler-rest/build.gradle
+++ b/error-handler-rest/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation project(":error-handler-core")
+    api project(":error-handler-core")
 
     api "com.halcyonmobile.retrofit-error-parsing:retrofit-error-parsing:1.0.0"
 


### PR DESCRIPTION
## Summary
* Removes the error-handler-core from the application app module and the app core will expose it.
* **error-handler-rest** can't be used without the **error-handler-core**. For this, the rest module will expose it's transitive dependency to **error-handler-core**.
* Add the bintray deployment setup.

## How to test
* Sync the project
* run the `publishToMavenLocal` gradle task (make sure to run for the whole project or for both lib modules). This will create an artifact in the local maven repository.
* Add mavenLocal() below jCenter() in repositories { .. } 
```
repositories {
        ...
        jcenter()
        mavenLocal()
        ...
    }
```
* Change the dependency in the app-core module from `api project(':error-handler-rest')`
 to  `api "com.halcyonmobile.error-handler:rest:0.1.0"`
* Sync & Install the app